### PR TITLE
Fix Ink script and restore runtime compilation

### DIFF
--- a/data/recipes.json
+++ b/data/recipes.json
@@ -5,12 +5,12 @@
       "vermouth": 1
     }
   },
-  "Whiskey (neat)": {
+  "Whiskey_neat": {
     "ingredients": {
       "whiskey": 1
     }
   },
-  "Rum (neat)": {
+  "Rum_neat": {
     "ingredients": {
       "rum": 1
     }

--- a/ink/story.ink
+++ b/ink/story.ink
@@ -9,7 +9,7 @@ The woods are quiet tonight... too quiet. You wonder what kind of souls the stor
 A figure pushes open the door, trailing rainwater. A weary traveler, by the look of him, in a crumpled coat and fedora.
 "Cold night, huh?" he mutters, meeting your eyes briefly.
 *   (friendly) "Warm yourself up. What'll it be?" -> order1
-*   (quiet) *Nod and wait for his order.* -> order1
+*   (quiet) Nod and wait for his order. -> order1
 
 === order1 ===
 "Martini, thanks. Extra dry." #RECIPE: Martini
@@ -29,7 +29,7 @@ A gruff lumberjack type, red-cheeked from the cold.
 "Bourbon. Neat," he barks, slapping a ten on the bar. 
 "Make it a double if you've got it."
 You reach for the whiskey bottle.
-The amber liquid swirls into the glass. #RECIPE: Whiskey (neat)
+The amber liquid swirls into the glass. #RECIPE: Whiskey_neat
 It's the last of the whiskey – the bottle runs dry. #INGREDIENT: whiskey -1
 He shoots it back in one go and grunts in approval.
 "Keep the change," he mumbles, tossing a couple of crumpled bills. #TIP: 3 #SCORE: 1
@@ -50,7 +50,7 @@ You freeze, remembering the empty whiskey bottle.
 === offer_rum ===
 "We're out of whiskey, but how about a dark rum? On the house."
 He raises an eyebrow, then nods slowly. "Fine."
-You pour a measure of aged rum and slide it over. #RECIPE: Rum (neat) #INGREDIENT: rum -1
+You pour a measure of aged rum and slide it over. #RECIPE: Rum_neat #INGREDIENT: rum -1
 He takes a sip. "Not bad," he concedes, a hint of a smirk on his face.
 He leaves a small tip, despite it being on the house. #TIP: 2 #SCORE: 1
 "Good night," he says, tipping his hat as he departs.

--- a/main.js
+++ b/main.js
@@ -342,22 +342,18 @@ function spawnGuest() {
 async function startGame() {
   await loadInitialData();
   const inkSource = await (await fetch("ink/story.ink")).text();
+  if (inkjs.Compiler && typeof inkjs.Compiler.loadWasmModule === "function") {
+    await inkjs.Compiler.loadWasmModule("https://cdn.jsdelivr.net/npm/inkjs@2.3.2/dist/ink.wasm");
+  }
+
   let compiled;
   try {
-    // inkjs 2.x requires its WASM module to be loaded before compiling
-    if (inkjs?.Compiler && typeof inkjs.Compiler.loadWasmModule === "function") {
-      await inkjs.Compiler.loadWasmModule("https://cdn.jsdelivr.net/npm/inkjs@2.3.2/dist/ink.wasm");
-      compiled = new inkjs.Compiler(inkSource).Compile();
-    } else if (typeof inkjs.compile === "function") {
-      // newer inkjs exposes a top level async compile function
-      compiled = await inkjs.compile(inkSource);
-    } else {
-      compiled = new inkjs.Compiler(inkSource).Compile();
-    }
+    compiled = new inkjs.Compiler(inkSource).Compile();
   } catch (e) {
     console.error("Failed to compile Ink story", e);
     return;
   }
+
   story = new inkjs.Story(compiled);
   const btJson = await (await fetch("ai/GuestBehavior.json")).json();
   loadBehaviorTree(btJson);

--- a/story.ink
+++ b/story.ink
@@ -15,7 +15,7 @@ The woods are quiet tonight... too quiet. You wonder what kind of souls the stor
 A figure pushes open the door, trailing rainwater. A weary traveler, by the look of him, in a crumpled coat and fedora.
 "Cold night, huh?" he mutters, meeting your eyes briefly.
 *   (friendly) "Warm yourself up. What'll it be?" -> order1
-*   (quiet) *Nod and wait for his order.* -> order1
+*   (quiet) Nod and wait for his order. -> order1
 
 // Order from first guest:
 === order1 ===
@@ -45,7 +45,7 @@ A gruff lumberjack type, red-cheeked from the cold.
 "Bourbon. Neat," he barks, slapping a ten on the bar. 
 "Make it a double if you've got it."
 You reach for the whiskey bottle.
-The amber liquid swirls into the glass. #RECIPE: Whiskey (neat)
+The amber liquid swirls into the glass. #RECIPE: Whiskey_neat
 It's the last of the whiskey – the bottle runs dry. #INGREDIENT: whiskey -1
 He shoots it back in one go and grunts in approval.
 "Keep the change," he mumbles, tossing a couple of crumpled bills. #TIP: 3 #SCORE: 1
@@ -76,7 +76,7 @@ You freeze, remembering the empty whiskey bottle.
 === offer_rum ===
 "We're out of whiskey, but how about a dark rum? On the house."
 He raises an eyebrow, then nods slowly. "Fine."
-You pour a measure of aged rum and slide it over. #RECIPE: Rum (neat) #INGREDIENT: rum -1
+You pour a measure of aged rum and slide it over. #RECIPE: Rum_neat #INGREDIENT: rum -1
 He takes a sip. "Not bad," he concedes, a hint of a smirk on his face.
 He leaves a small tip, despite it being on the house. #TIP: 2 #SCORE: 1
 "Good night," he says, tipping his hat as he departs.
@@ -97,7 +97,7 @@ Two burly men lug crates into your storeroom, replenishing your stock for tomorr
 The bar is quiet again, the only sound the hum of the refrigerator and the patter of rain. 
 It's been a long night, but a decent one.
 ${tips} dollars in tips, and a job well done. #SCORE: ${score}
-<- END ->
 
 // Note: ${tips} and ${score} would normally refer to Ink variables if tracked in story, 
 // but we use tags and let the game display final totals via ScoreComponent.
+-> END


### PR DESCRIPTION
## Summary
- Remove unsupported italics in Ink choice and rename recipe tags
- Update recipes JSON and ensure Ink story ends with `-> END`
- Simplify runtime Ink compilation with WASM module loading

## Testing
- `npx --yes inkjs ink/story.ink -o /tmp/story.json` *(fails: 403 Forbidden fetching inkjs from npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bcad7143248328a80230f2425a962e